### PR TITLE
merge config.env into the process.env instead of replacing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "execute external processed with a simple API",
   "main": "shellton.js",
   "dependencies": {
-    "async": "^1.5.2"
+    "async": "^1.5.2",
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/shellton.js
+++ b/shellton.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var child = require('child_process');
 var async = require('async');
+var _ = require('lodash');
 
 // Add the node_modules to the PATH
 var nodeModulesGlobal = path.resolve(__dirname, 'node_modules', '.bin');
@@ -28,6 +29,10 @@ function getConfig(command) {
     }
     
     return config;
+}
+
+function getEnv(config) {
+    return _.extend({}, config.env || {}, process.env);
 }
 
 function isIOStream(stream) {
@@ -59,7 +64,7 @@ function exec(command, done) {
     
     var task = child.exec(config.task, {
         cwd: config.cwd || process.cwd(),
-        env: config.env || process.env
+        env: getEnv(config)
     }, function(err, stdout, stderr) {
         done(err, stdout, stderr);
     });
@@ -102,7 +107,7 @@ function spawn(command, done) {
     var tokens = [firstToken, config.task];
     
     var task = child.spawn(executable, tokens, {
-        env: config.env || process.env,
+        env: getEnv(config),
         cwd: config.cwd || process.cwd(),
         stdio: stdio
     });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -70,9 +70,11 @@ function addTests(shell) {
             });
         });
         
-        it('can execute NPM modules from bin', function(done) {
+        it('can execute NPM modules from bin when env is set', function(done) {
             shell({
-                task: 'istanbul help'
+                task: 'istanbul help',
+                // env must be set
+                env: {}
             }, function(err, stdout, stderr) {
                 expect(err).to.not.be.ok;
                 expect(stdout.trim()).to.equal('');

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -70,6 +70,20 @@ function addTests(shell) {
             });
         });
         
+        it('can execute NPM modules from bin', function(done) {
+            shell({
+                task: 'istanbul help'
+            }, function(err, stdout, stderr) {
+                expect(err).to.not.be.ok;
+                expect(stdout.trim()).to.equal('');
+                
+                expect(stderr).to.be.a('string')
+                    .and.to.have.length.above(50);
+                
+                done();
+            });
+        });
+        
         describe('streams to', function() {
             function testStream(opts, stream, done) {
                 var shellOut, streamOut, c = 0;


### PR DESCRIPTION
This is the behavior I always assumed and would prefer.
