### PR TITLE
using windowsVerbatimArguments by default for spawn

### DIFF
--- a/shellton.js
+++ b/shellton.js
@@ -114,11 +114,17 @@ function spawn(command, done) {
     var firstToken = platform === 'win' ? '/c' : '-c';
     var tokens = [firstToken, config.task];
     
-    var task = child.spawn(executable, tokens, {
+    var opts = {
         env: getEnv(config),
         cwd: config.cwd || process.cwd(),
         stdio: stdio
-    });
+    };
+    
+    if (/^win/.test(process.platform)) {
+        opts.windowsVerbatimArguments = config.windowsVerbatimArguments !== false;
+    }
+    
+    var task = child.spawn(executable, tokens, opts);
     
     task.on('error', function(err) {
         done(err);


### PR DESCRIPTION
This makes the behavior match `exec` as well as Linux command behavior... and overall makes you wonder why your command is not working a whole lot less.