### PR TITLE
using default shell on any system other than windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "shellton.js",
   "dependencies": {
     "async": "^2.0.1",
-    "default-shell": "^1.0.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "shellton.js",
   "dependencies": {
     "async": "^2.0.1",
+    "default-shell": "^1.0.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/shellton.js
+++ b/shellton.js
@@ -5,6 +5,7 @@ var child = require('child_process');
 
 var async = require('async');
 var _ = require('lodash');
+var defaultShell = require('default-shell');
 
 // Add the node_modules to the PATH
 var nodeModulesBin = path.resolve(__dirname, 'node_modules', '.bin');
@@ -183,7 +184,7 @@ function spawn(command, done) {
         }   
     }
     
-    var executable = platform === 'win' ? 'cmd.exe' : 'bash';
+    var executable = platform === 'win' ? 'cmd.exe' : defaultShell;
     var firstToken = platform === 'win' ? '/c' : '-c';
     var tokens = [firstToken, config.task];
     

--- a/shellton.js
+++ b/shellton.js
@@ -5,7 +5,6 @@ var child = require('child_process');
 
 var async = require('async');
 var _ = require('lodash');
-var defaultShell = require('default-shell');
 
 // Add the node_modules to the PATH
 var nodeModulesBin = path.resolve(__dirname, 'node_modules', '.bin');
@@ -20,6 +19,26 @@ var platform = /^win/.test(process.platform) ? 'win' : 'nix';
 var VERSION = process.versions.node.match(/([0-9]+)\.([0-9]+)\.([0-9]+)/);
 var IS_NODE_0_10 = +VERSION[1] === 0 && +VERSION[2] < 12;
 var BUFFER_ENCODING = IS_NODE_0_10 ? 'binary' : 'buffer';
+
+var defaultShell = (function () {
+    // adapted from https://github.com/sindresorhus/default-shell
+    var env = process.env;
+
+    if (process.platform === 'darwin') {
+        return env.SHELL || '/bin/bash';
+    }
+
+    if (process.platform === 'win32') {
+        // Powershell behaves differently at times, so I am reluctant to
+        // just enable this, especially since Microsoft has started making
+        // Powershell the default in newer versions of Windows.
+        // return env.COMSPEC || 'cmd.exe';
+        
+        return 'cmd.exe';
+    }
+
+    return env.SHELL || '/bin/sh';
+})();
 
 function validateFunction(obj) {
     return _.isFunction(obj) ? obj : _.noop;
@@ -184,7 +203,6 @@ function spawn(command, done) {
         }   
     }
     
-    var executable = platform === 'win' ? 'cmd.exe' : defaultShell;
     var firstToken = platform === 'win' ? '/c' : '-c';
     var tokens = [firstToken, config.task];
     
@@ -198,7 +216,7 @@ function spawn(command, done) {
         opts.windowsVerbatimArguments = config.windowsVerbatimArguments !== false;
     }
     
-    var task = child.spawn(executable, tokens, opts);
+    var task = child.spawn(defaultShell, tokens, opts);
     
     task.on('error', function(err) {
         done(err);


### PR DESCRIPTION
#32 

On Windows, we will continue to use cmd.exe. Powershell behaves differently.

In all other systems, the [default shell](https://github.com/sindresorhus/default-shell) will be used.